### PR TITLE
Drop unused template for transport_url

### DIFF
--- a/templates/ceilometer/config/ceilometer.conf
+++ b/templates/ceilometer/config/ceilometer.conf
@@ -4,7 +4,6 @@ tenant_name_discovery=False
 debug=True
 log_dir=/var/log/ceilometer
 rpc_response_timeout=60
-transport_url={{ .transportURL }}
 polling_namespaces=central
 
 [service_credentials]
@@ -36,7 +35,6 @@ notify_address_prefix=
 
 [oslo_messaging_notifications]
 driver=messagingv2
-transport_url={{ .transportURL }}
 topics=notifications
 
 [publisher]


### PR DESCRIPTION
The transport_url options are set by init.sh from secrets and we do not use template mechanism for the options.

Signed-off-by: Takashi Kajinami <tkajinam@redhat.com>