### PR TITLE
Fix golint errors

### DIFF
--- a/pkg/ceilometer/const.go
+++ b/pkg/ceilometer/const.go
@@ -24,7 +24,9 @@ const (
 	// CeilometerPrometheusPort -
 	CeilometerPrometheusPort int32 = 3000
 
-	// KollaConfig -
-	KollaConfigCentral      = "/var/lib/config-data/merged/config-central.json"
+	// KollaConfigCentral -
+	KollaConfigCentral = "/var/lib/config-data/merged/config-central.json"
+
+	// KollaConfigNotification -
 	KollaConfigNotification = "/var/lib/config-data/merged/config-notification.json"
 )

--- a/pkg/ceilometer/deployment.go
+++ b/pkg/ceilometer/deployment.go
@@ -160,7 +160,7 @@ func Deployment(
 	}
 	deployment.Spec.Template.Annotations = util.MergeStringMaps(deployment.Spec.Template.Annotations, nwAnnotation)
 
-	initContainerDetails := CeilometerDetails{
+	initContainerDetails := APIDetails{
 		ContainerImage:           instance.Spec.InitImage,
 		RabbitMQSecret:           instance.Spec.RabbitMQSecret,
 		RabbitMQHostSelector:     instance.Spec.RabbitMQSelectors.Host,

--- a/pkg/ceilometer/initcontainer.go
+++ b/pkg/ceilometer/initcontainer.go
@@ -21,8 +21,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// CeilometerDetails information
-type CeilometerDetails struct {
+// APIDetails information
+type APIDetails struct {
 	ContainerImage           string
 	RabbitMQSecret           string
 	RabbitMQHostSelector     string
@@ -38,7 +38,7 @@ const (
 )
 
 // initContainer - init container for ceilometer api pods
-func initContainer(init CeilometerDetails) []corev1.Container {
+func initContainer(init APIDetails) []corev1.Container {
 	runAsUser := int64(0)
 
 	args := []string{


### PR DESCRIPTION
This fixes the following errors from golint.

```
Error: pkg/ceilometer/const.go:27:2: comment on exported const KollaConfigCentral should be of the form "KollaConfigCentral ..."
Error: pkg/ceilometer/const.go:29:2: exported const KollaConfigNotification should have comment (or a comment on this block) or be unexported
Error: pkg/ceilometer/initcontainer.go:25:6: type name will be used as ceilometer.CeilometerDetails by other packages, and that stutters; consider calling this Details
```

Signed-off-by: Takashi Kajinami <tkajinam@redhat.com>