### PR TITLE
Add build_root_image configuration for prow

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  name: tools
+  namespace: openstack-k8s-operators
+  tag: ci-build-root-golang-1.19-sdk-1.26


### PR DESCRIPTION
ci-operator is the tool that handles the process of building images and running workflows in Prow jobs. By adding this configuration in the repo, we can replace the base_root) image [1] (which will serve as base for most of the jobs) along with code changes, when upgrading dependencies (golang for instance).

This file has no effect for now, only after updating ci-operator config on openshift/release, in another PR.

[1]: https://docs.ci.openshift.org/docs/architecture/ci-operator/#build-root-image