### PR TITLE
Write logs to stdout

### DIFF
--- a/templates/ceilometer/config/config-central.json
+++ b/templates/ceilometer/config/config-central.json
@@ -1,5 +1,5 @@
 {
-    "command": "/usr/bin/ceilometer-polling --polling-namespaces central --logfile /var/log/ceilometer/central.log",
+    "command": "/usr/bin/ceilometer-polling --polling-namespaces central --logfile /dev/stdout",
     "config_files": [
       {
         "source": "/var/lib/config-data/merged/ceilometer.conf",

--- a/templates/ceilometer/config/config-notification.json
+++ b/templates/ceilometer/config/config-notification.json
@@ -1,5 +1,5 @@
 {
-    "command": "/usr/bin/ceilometer-agent-notification --logfile /var/log/ceilometer/agent-notification.log",
+    "command": "/usr/bin/ceilometer-agent-notification --logfile /dev/stdout",
     "config_files": [
       {
         "source": "/var/lib/config-data/merged/ceilometer.conf",


### PR DESCRIPTION
Make ceilometer write its logs to stdout, instead of a file.