### PR TITLE
Drop gotest from precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,12 +36,6 @@ repos:
       entry: make
       args: ['govet']
       pass_filenames: false
-    - id: make-gotest
-      name: make-gotest
-      language: system
-      entry: make
-      args: ['gotest']
-      pass_filenames: false
     - id: make-golangci
       name: make-golangci
       language: system


### PR DESCRIPTION
Precommit tests are meant to run quickly within seconds, dropping gotests from precommit as once the list of tests grows they starts to take more time and not a good candidate for precommit.

