### PR TITLE
Extra : after ceilometer-approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 approvers:
-  - ceilometer-approvers:
+  - ceilometer-approvers
   - ci-approvers
 
 reviewers:


### PR DESCRIPTION
This is causing failure in periodic job[1]

~~~
 level=error msg="Unable to load simple config."
 error="error unmarshaling JSON: while decoding JSON: json:
 cannot unmarshal object into Go struct field SimpleConfig.approvers of type string"
~~~

[1] https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-prow-auto-owners/1642801727776231424